### PR TITLE
Follow-up:Improve player name parsing: support non-Latin names and ignore <...> system tags

### DIFF
--- a/Mabinogi_Damage_Tracker.Server/Parser.cs
+++ b/Mabinogi_Damage_Tracker.Server/Parser.cs
@@ -643,7 +643,9 @@ namespace Mabinogi_Damage_tracker
 
                 string playername = Encoding.UTF8.GetString(packet.PayloadData, cursor, (int)namelength - 1);
 
-                if (Regex.IsMatch(playername, @"[^a-zA-Z0-9+]")) { return; }
+                if (string.IsNullOrWhiteSpace(playername)) { return; }
+                playername = playername.Trim();
+                if (playername.Any(char.IsControl)) { return; }
 
                 //character_names.Add(new Name(playername, playerid));
                 db_helper.add_player(playername, (Int64)playerid);

--- a/Mabinogi_Damage_Tracker.Server/Parser.cs
+++ b/Mabinogi_Damage_Tracker.Server/Parser.cs
@@ -647,6 +647,8 @@ namespace Mabinogi_Damage_tracker
                 playername = playername.Trim();
                 if (playername.Any(char.IsControl)) { return; }
 
+                if (playername.Length >= 3 && playername.StartsWith("<") && playername.EndsWith(">")) { return; }
+                
                 //character_names.Add(new Name(playername, playerid));
                 db_helper.add_player(playername, (Int64)playerid);
                 LogsController.WriteLog("[PLAYER DISCOVERED]" + playerid.ToString() + " -> " + playername);


### PR DESCRIPTION
This PR is a follow-up to the previously closed PR #7.

This PR improves player name parsing to better support KR/JP/CN regions.

Previously, player names were restricted to ASCII alphanumeric characters, which prevented non-Latin names from being registered.

This update:

Allows UTF-8 player names (non-Latin characters supported)
Rejects only empty or control-character names
Ignores system-style tags wrapped in angle brackets (e.g. "", "") to prevent accidental registration
This ensures better regional compatibility while preventing system messages from being stored as player names.

Tested with:

Japanese names
ASCII names
System tag messages