### PR TITLE
Db disk io optimizing

### DIFF
--- a/Mabinogi_Damage_Tracker.Server/Controllers/HomeController.cs
+++ b/Mabinogi_Damage_Tracker.Server/Controllers/HomeController.cs
@@ -180,6 +180,18 @@ namespace Mabinogi_Damage_tracker.Controllers
             return Ok(adapter);
         }
 
+        public IActionResult SaveFlushSettings(int enable, int ms)
+        {
+            db_helper.Set_Flush_Settings(enable, ms);
+            return Ok();
+        }
+
+        public IActionResult GetFlushSettings(int enable, int ms)
+        {
+            
+            return Json(db_helper.Get_Flush_Settings());
+        }
+
         public ActionResult Clear_Damage_DB()
         {
             db_helper.Clear_Damage_DB();

--- a/Mabinogi_Damage_Tracker.Server/Parser.cs
+++ b/Mabinogi_Damage_Tracker.Server/Parser.cs
@@ -37,6 +37,8 @@ namespace Mabinogi_Damage_tracker
 #if DEBUG_FILE
         private static DateTime? _firstPacketTime = null;
         private static Stopwatch _realTimeClock = new Stopwatch();
+        private static bool enable_realtime = true;
+        private static float playbackspeed = 5;
 #endif
 
         private sealed class RecentDamageHit
@@ -210,7 +212,7 @@ namespace Mabinogi_Damage_tracker
                 device.OnPacketArrival += Device_OnPacketArrival;
                 captureFileWriter.Open();
 #if DEBUG_FILE
-                Thread.Sleep(10000);
+                Thread.Sleep(15000);
                 device.Capture();
 #endif
 #if DEBUG_LIVE || RELEASE
@@ -234,21 +236,24 @@ namespace Mabinogi_Damage_tracker
             RawCapture raw = e.GetPacket();
 
 #if DEBUG_FILE
-            var packetTime = e.GetPacket().Timeval.Date;
-
-            if (_firstPacketTime == null)
+            if (enable_realtime == true)
             {
-                _firstPacketTime = packetTime;
-                _realTimeClock.Start();
-            }
-            else
-            {
-                TimeSpan expectedTimePassed = packetTime - _firstPacketTime.Value;
-                TimeSpan timeToWait = expectedTimePassed - _realTimeClock.Elapsed;
+                var packetTime = e.GetPacket().Timeval.Date;
 
-                if (timeToWait > TimeSpan.Zero)
+                if (_firstPacketTime == null)
                 {
-                    Thread.Sleep(timeToWait);
+                    _firstPacketTime = packetTime;
+                    _realTimeClock.Start();
+                }
+                else
+                {
+                    TimeSpan expectedTimePassed = (packetTime - _firstPacketTime.Value)/playbackspeed;
+                    TimeSpan timeToWait = expectedTimePassed - _realTimeClock.Elapsed;
+
+                    if (timeToWait > TimeSpan.Zero)
+                    {
+                        Thread.Sleep(timeToWait);
+                    }
                 }
             }
 #endif

--- a/Mabinogi_Damage_Tracker.Server/db_helper.cs
+++ b/Mabinogi_Damage_Tracker.Server/db_helper.cs
@@ -2,8 +2,10 @@ using Mabinogi_Damage_tracker.Models;
 using Mabinogi_Damage_Tracker;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Data.Sqlite;
+using SharpPcap;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Xml.Linq;
 
@@ -18,10 +20,34 @@ namespace Mabinogi_Damage_tracker
         public record HealRecord(ulong Healer, ulong Recipient, uint HealAmount, long ut);
         private static readonly ConcurrentQueue<HealRecord> _healQueue = new ConcurrentQueue<HealRecord>();
         private static readonly System.Timers.Timer FlushTimer;
+        private static bool DisableFlush = false;
+        
+        public record FlushSettings(int ms, int enable);
         
         static db_helper()
         {
-            FlushTimer = new System.Timers.Timer(5000);
+            FlushSettings flush = Get_Flush_Settings();
+            if(flush == null) // set default flush settings if non present
+            {
+                using (SqliteConnection connection = new SqliteConnection(db_connection))
+                {
+                    connection.Open();
+                    SqliteCommand sqliteCommand = connection.CreateCommand();
+                    string create_flushsettings = @"
+                    CREATE TABLE IF NOT EXISTS flush_settings(
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        flush_ms INTEGER NOT NULL,
+                        enable INTEGER NOT NULL
+                    )";
+                    sqliteCommand.CommandText = create_flushsettings;
+                    sqliteCommand.ExecuteNonQuery();
+                }
+
+                Set_Flush_Settings(1, 1000);
+                flush = Get_Flush_Settings();
+            }
+           if(flush.enable == 0) { DisableFlush = true; return; }
+            FlushTimer = new System.Timers.Timer(flush.ms);
             FlushTimer.Elapsed += (sender, e) =>
             {
                 FlushDamageQueue();
@@ -29,6 +55,7 @@ namespace Mabinogi_Damage_tracker
             };
             FlushTimer.AutoReset = true;
             FlushTimer.Start();
+
         }
 
 
@@ -87,9 +114,8 @@ namespace Mabinogi_Damage_tracker
                         adapter TEXT
                     )";
 
-                //enable WAL to improve preformance on slow drives
-                //sqliteCommand.CommandText = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";
-                //sqliteCommand.ExecuteNonQuery();
+
+
 
                 sqliteCommand.CommandText = create_playerid;
                 sqliteCommand.ExecuteNonQuery();
@@ -104,6 +130,7 @@ namespace Mabinogi_Damage_tracker
                 sqliteCommand.ExecuteNonQuery();
                 sqliteCommand.CommandText = create_adapter;
                 sqliteCommand.ExecuteNonQuery();
+
             }
         }
 
@@ -193,6 +220,36 @@ namespace Mabinogi_Damage_tracker
 
         public static void add_damage(Int64 playerid, double damage, double wound, int manadamage, Int64 enemyid, int skill, int subskill, long actionpackid, long combatactionid, long options)
         {
+            if(DisableFlush == true)
+            {
+                try
+                {
+                    using (SqliteConnection connection = new SqliteConnection(db_connection))
+                    {
+                        connection.Open();
+                        SqliteCommand add_command = new SqliteCommand(@"
+                    INSERT INTO damages (playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options, dt, ut)
+                        VALUES(@id,@dmg,@wound,@manadamage,@enemyid,@skill,@subskill,@actionpackid,@combatactionid,@options,datetime(), unixepoch())
+                    ", connection);
+                        add_command.Parameters.AddWithValue("@id", playerid);
+                        add_command.Parameters.AddWithValue("@dmg", damage);
+                        add_command.Parameters.AddWithValue("@wound", wound);
+                        add_command.Parameters.AddWithValue("@manadamage", manadamage);
+                        add_command.Parameters.AddWithValue("@enemyid", enemyid);
+                        add_command.Parameters.AddWithValue("@skill", skill);
+                        add_command.Parameters.AddWithValue("@subskill", subskill);
+                        add_command.Parameters.AddWithValue("@actionpackid", actionpackid);
+                        add_command.Parameters.AddWithValue("@combatactionid", combatactionid);
+                        add_command.Parameters.AddWithValue("@options", options);
+                        add_command.ExecuteNonQueryAsync();
+                    }
+                }
+                catch
+                {
+                    Debug.WriteLine("couldnt send sql command");
+                }
+                return; 
+            }
             _damageQueue.Enqueue(new DamageHitRecord(playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options, DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
         
         }
@@ -342,6 +399,28 @@ namespace Mabinogi_Damage_tracker
 
         public static void add_heal (UInt64 healer, UInt64 recipient, UInt32 heal)
         {
+            if(DisableFlush == true)
+            {
+                try
+                {
+                    using (SqliteConnection connection = new SqliteConnection(db_connection))
+                    {
+                        connection.Open();
+                        SqliteCommand add_command = new SqliteCommand(@"
+                    INSERT INTO heals (healer, heal, recipient, dt, ut)
+                        VALUES(@healer,@heal,@rec,datetime(), unixepoch())
+                    ", connection);
+                        add_command.Parameters.AddWithValue("@healer", healer);
+                        add_command.Parameters.AddWithValue("@heal", heal);
+                        add_command.Parameters.AddWithValue("@rec", recipient);
+                        add_command.ExecuteNonQueryAsync();
+                    }
+                }
+                catch
+                {
+                    Debug.WriteLine("couldnt send sql command");
+                }
+            }
             _healQueue.Enqueue(new HealRecord(healer, recipient, heal, DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
         }
 
@@ -1206,6 +1285,61 @@ namespace Mabinogi_Damage_tracker
             }
         }
 
+        public static void Set_Flush_Settings(int enable, int ms)
+        {
+            try
+            {
+                using (SqliteConnection connection = new SqliteConnection(db_connection))
+                {
+                    connection.Open();
+                    SqliteCommand command = new SqliteCommand(@"
+                        delete from flush_settings;
+                        insert into flush_settings (flush_ms, enable)
+                            values(@ms, @en)
+                    ", connection);
+                    command.Parameters.AddWithValue("@en", enable);
+                    command.Parameters.AddWithValue("@ms", ms);
+                    command.ExecuteNonQuery();
+                }
+            }
+            catch
+            {
+                Debug.WriteLine("could not send sql command");
+            }
+        }
+
+        public static FlushSettings Get_Flush_Settings()
+        {
+            FlushSettings results;
+            try
+            {
+                using (SqliteConnection connection = new SqliteConnection(db_connection))
+                {
+                    connection.Open();
+                    SqliteCommand command = new SqliteCommand(@"
+                    select flush_ms, enable from flush_settings order by id DESC limit 1
+                    ", connection);
+
+
+                    using (var reader = command.ExecuteReader())
+                    {
+                        reader.Read();
+                        results = new FlushSettings(reader.GetInt32(0), reader.GetInt32(1) );
+                    }
+
+                    if (results != null)
+                    { 
+                        return results;
+                    }
+                }
+            }
+            catch
+            {
+                Debug.WriteLine("could not send sql command");
+               
+            }
+            return null;
+        }
 
     }
 }

--- a/Mabinogi_Damage_Tracker.Server/db_helper.cs
+++ b/Mabinogi_Damage_Tracker.Server/db_helper.cs
@@ -13,11 +13,12 @@ namespace Mabinogi_Damage_tracker
     {
         private static string db_connection = @"Data Source=trackerdb.db;";
         private static readonly ConcurrentQueue<DamageHitRecord> _damageQueue = new ConcurrentQueue<DamageHitRecord>();
-        public record HealRecord(ulong Healer, ulong Recipient, uint HealAmount);
-        private static readonly ConcurrentQueue<HealRecord> _healQueue = new ConcurrentQueue<HealRecord>();
+        public record DamageHitRecord(Int64 PlayerId, double Damage, double Wound, int ManaDamage, Int64 EnemyId, int Skill, int Subskill, long ActionpackId, long CombatActionId, long Options, long ut);
 
+        public record HealRecord(ulong Healer, ulong Recipient, uint HealAmount, long ut);
+        private static readonly ConcurrentQueue<HealRecord> _healQueue = new ConcurrentQueue<HealRecord>();
         private static readonly System.Timers.Timer FlushTimer;
-        public record DamageHitRecord(Int64 PlayerId, double Damage, double Wound, int ManaDamage, Int64 EnemyId, int Skill, int Subskill, long ActionpackId, long CombatActionId, long Options);
+        
         static db_helper()
         {
             FlushTimer = new System.Timers.Timer(5000);
@@ -87,8 +88,8 @@ namespace Mabinogi_Damage_tracker
                     )";
 
                 //enable WAL to improve preformance on slow drives
-                sqliteCommand.CommandText = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";
-                sqliteCommand.ExecuteNonQuery();
+                //sqliteCommand.CommandText = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";
+                //sqliteCommand.ExecuteNonQuery();
 
                 sqliteCommand.CommandText = create_playerid;
                 sqliteCommand.ExecuteNonQuery();
@@ -192,7 +193,7 @@ namespace Mabinogi_Damage_tracker
 
         public static void add_damage(Int64 playerid, double damage, double wound, int manadamage, Int64 enemyid, int skill, int subskill, long actionpackid, long combatactionid, long options)
         {
-            _damageQueue.Enqueue(new DamageHitRecord(playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options));
+            _damageQueue.Enqueue(new DamageHitRecord(playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options, DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
         
         }
 
@@ -215,15 +216,14 @@ namespace Mabinogi_Damage_tracker
                 {
                     connection.Open();
 
-                    // Begin an explicit transaction! This is the magic that fixes the HDD lag.
                     using (var transaction = connection.BeginTransaction())
                     {
                         using (var command = new SqliteCommand(@"
-                    INSERT INTO damages (playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options, dt, ut)
-                    VALUES(@id, @dmg, @wound, @manadamage, @enemyid, @skill, @subskill, @actionpackid, @combatactionid, @options, datetime(), unixepoch())
-                ", connection, transaction))
+                            INSERT INTO damages (playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options, dt, ut)
+                            VALUES(@id, @dmg, @wound, @manadamage, @enemyid, @skill, @subskill, @actionpackid, @combatactionid, @options, datetime(), @ut)
+                            ", connection, transaction))
                         {
-                            // Create parameters once to save CPU cycles
+
                             command.Parameters.Add("@id", SqliteType.Integer);
                             command.Parameters.Add("@dmg", SqliteType.Real);
                             command.Parameters.Add("@wound", SqliteType.Real);
@@ -234,8 +234,8 @@ namespace Mabinogi_Damage_tracker
                             command.Parameters.Add("@actionpackid", SqliteType.Integer);
                             command.Parameters.Add("@combatactionid", SqliteType.Integer);
                             command.Parameters.Add("@options", SqliteType.Integer);
+                            command.Parameters.Add("@ut", SqliteType.Integer);
 
-                            // Loop through the batch, updating parameter values and executing
                             foreach (var hit in batch)
                             {
                                 command.Parameters["@id"].Value = hit.PlayerId;
@@ -248,11 +248,10 @@ namespace Mabinogi_Damage_tracker
                                 command.Parameters["@actionpackid"].Value = hit.ActionpackId;
                                 command.Parameters["@combatactionid"].Value = hit.CombatActionId;
                                 command.Parameters["@options"].Value = hit.Options;
-
+                                command.Parameters["@ut"].Value = hit.ut;
                                 command.ExecuteNonQuery();
                             }
                         }
-                        // Commit the entire batch to the hard drive at once
                         transaction.Commit();
                     }
                 }
@@ -343,7 +342,7 @@ namespace Mabinogi_Damage_tracker
 
         public static void add_heal (UInt64 healer, UInt64 recipient, UInt32 heal)
         {
-            _healQueue.Enqueue(new HealRecord(healer, recipient, heal));
+            _healQueue.Enqueue(new HealRecord(healer, recipient, heal, DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
         }
 
         public static void FlushHealQueue()
@@ -367,19 +366,19 @@ namespace Mabinogi_Damage_tracker
                     {
                         using (var command = new SqliteCommand(@"
                     INSERT INTO heals (healer, heal, recipient, dt, ut)
-                    VALUES(@healer, @heal, @rec, datetime(), unixepoch())
+                    VALUES(@healer, @heal, @rec, datetime(), @ut)
                 ", connection, transaction))
                         {
                             command.Parameters.Add("@healer", SqliteType.Integer);
                             command.Parameters.Add("@heal", SqliteType.Integer);
                             command.Parameters.Add("@rec", SqliteType.Integer);
-
+                            command.Parameters.Add("@ut", SqliteType.Integer);
                             foreach (var item in batch)
                             {
                                 command.Parameters["@healer"].Value = item.Healer;
                                 command.Parameters["@heal"].Value = item.HealAmount;
                                 command.Parameters["@rec"].Value = item.Recipient;
-
+                                command.Parameters["@ut"].Value = item.ut;
                                 command.ExecuteNonQuery();
                             }
                         }

--- a/Mabinogi_Damage_Tracker.Server/db_helper.cs
+++ b/Mabinogi_Damage_Tracker.Server/db_helper.cs
@@ -13,12 +13,19 @@ namespace Mabinogi_Damage_tracker
     {
         private static string db_connection = @"Data Source=trackerdb.db;";
         private static readonly ConcurrentQueue<DamageHitRecord> _damageQueue = new ConcurrentQueue<DamageHitRecord>();
+        public record HealRecord(ulong Healer, ulong Recipient, uint HealAmount);
+        private static readonly ConcurrentQueue<HealRecord> _healQueue = new ConcurrentQueue<HealRecord>();
+
         private static readonly System.Timers.Timer FlushTimer;
         public record DamageHitRecord(Int64 PlayerId, double Damage, double Wound, int ManaDamage, Int64 EnemyId, int Skill, int Subskill, long ActionpackId, long CombatActionId, long Options);
         static db_helper()
         {
             FlushTimer = new System.Timers.Timer(5000);
-            FlushTimer.Elapsed += (sender, e) => FlushDamageQueue();
+            FlushTimer.Elapsed += (sender, e) =>
+            {
+                FlushDamageQueue();
+                FlushHealQueue();
+            };
             FlushTimer.AutoReset = true;
             FlushTimer.Start();
         }
@@ -336,24 +343,58 @@ namespace Mabinogi_Damage_tracker
 
         public static void add_heal (UInt64 healer, UInt64 recipient, UInt32 heal)
         {
+            _healQueue.Enqueue(new HealRecord(healer, recipient, heal));
+        }
+
+        public static void FlushHealQueue()
+        {
+            if (_healQueue.IsEmpty) return;
+
+            var batch = new List<HealRecord>();
+            while (_healQueue.TryDequeue(out var record))
+            {
+                batch.Add(record);
+            }
+
+            if (batch.Count == 0) return;
+
             try
             {
-                using (SqliteConnection connection = new SqliteConnection(db_connection))
+                using (var connection = new SqliteConnection(db_connection))
                 {
                     connection.Open();
-                    SqliteCommand add_command = new SqliteCommand(@"
+                    using (var transaction = connection.BeginTransaction())
+                    {
+                        using (var command = new SqliteCommand(@"
                     INSERT INTO heals (healer, heal, recipient, dt, ut)
-                        VALUES(@healer,@heal,@rec,datetime(), unixepoch())
-                    ", connection);
-                    add_command.Parameters.AddWithValue("@healer", healer);
-                    add_command.Parameters.AddWithValue("@heal", heal);
-                    add_command.Parameters.AddWithValue("@rec", recipient);
-                    add_command.ExecuteNonQueryAsync();
+                    VALUES(@healer, @heal, @rec, datetime(), unixepoch())
+                ", connection, transaction))
+                        {
+                            command.Parameters.Add("@healer", SqliteType.Integer);
+                            command.Parameters.Add("@heal", SqliteType.Integer);
+                            command.Parameters.Add("@rec", SqliteType.Integer);
+
+                            foreach (var item in batch)
+                            {
+                                command.Parameters["@healer"].Value = item.Healer;
+                                command.Parameters["@heal"].Value = item.HealAmount;
+                                command.Parameters["@rec"].Value = item.Recipient;
+
+                                command.ExecuteNonQuery();
+                            }
+                        }
+                        transaction.Commit();
+                    }
                 }
+                Debug.WriteLine($"[DB] Flushed {batch.Count} heal records to disk.");
             }
-            catch
+            catch (Exception ex)
             {
-                Debug.WriteLine("couldnt send sql command");
+                Debug.WriteLine($"[DB] Failed to flush heal batch: {ex.Message}");
+                foreach (var item in batch)
+                {
+                    _healQueue.Enqueue(item);
+                }
             }
         }
 

--- a/Mabinogi_Damage_Tracker.Server/db_helper.cs
+++ b/Mabinogi_Damage_Tracker.Server/db_helper.cs
@@ -1,16 +1,29 @@
-using System.Diagnostics;
-using System.Text.Json;
-using System.Xml.Linq;
 using Mabinogi_Damage_tracker.Models;
 using Mabinogi_Damage_Tracker;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Data.Sqlite;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Xml.Linq;
 
 namespace Mabinogi_Damage_tracker
 {
     public class db_helper
     {
         private static string db_connection = @"Data Source=trackerdb.db;";
+        private static readonly ConcurrentQueue<DamageHitRecord> _damageQueue = new ConcurrentQueue<DamageHitRecord>();
+        private static readonly System.Timers.Timer FlushTimer;
+        public record DamageHitRecord(Int64 PlayerId, double Damage, double Wound, int ManaDamage, Int64 EnemyId, int Skill, int Subskill, long ActionpackId, long CombatActionId, long Options);
+        static db_helper()
+        {
+            FlushTimer = new System.Timers.Timer(5000);
+            FlushTimer.Elapsed += (sender, e) => FlushDamageQueue();
+            FlushTimer.AutoReset = true;
+            FlushTimer.Start();
+        }
+
+
 
         public static void Initalize_db()
         {
@@ -66,6 +79,9 @@ namespace Mabinogi_Damage_tracker
                         adapter TEXT
                     )";
 
+                //enable WAL to improve preformance on slow drives
+                sqliteCommand.CommandText = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";
+                sqliteCommand.ExecuteNonQuery();
 
                 sqliteCommand.CommandText = create_playerid;
                 sqliteCommand.ExecuteNonQuery();
@@ -169,31 +185,80 @@ namespace Mabinogi_Damage_tracker
 
         public static void add_damage(Int64 playerid, double damage, double wound, int manadamage, Int64 enemyid, int skill, int subskill, long actionpackid, long combatactionid, long options)
         {
+            _damageQueue.Enqueue(new DamageHitRecord(playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options));
+        
+        }
+
+
+        private static void FlushDamageQueue()
+        {
+            if (_damageQueue.IsEmpty) return;
+
+            var batch = new List<DamageHitRecord>();
+            while (_damageQueue.TryDequeue(out var hit))
+            {
+                batch.Add(hit);
+            }
+
+            if (batch.Count == 0) return;
+
             try
             {
                 using (SqliteConnection connection = new SqliteConnection(db_connection))
                 {
                     connection.Open();
-                    SqliteCommand add_command = new SqliteCommand(@"
+
+                    // Begin an explicit transaction! This is the magic that fixes the HDD lag.
+                    using (var transaction = connection.BeginTransaction())
+                    {
+                        using (var command = new SqliteCommand(@"
                     INSERT INTO damages (playerid, damage, wound, manadamage, enemyid, skill, subskill, actionpackid, combatactionid, options, dt, ut)
-                        VALUES(@id,@dmg,@wound,@manadamage,@enemyid,@skill,@subskill,@actionpackid,@combatactionid,@options,datetime(), unixepoch())
-                    ", connection);
-                    add_command.Parameters.AddWithValue("@id", playerid);
-                    add_command.Parameters.AddWithValue("@dmg", damage);
-                    add_command.Parameters.AddWithValue("@wound", wound);
-                    add_command.Parameters.AddWithValue("@manadamage", manadamage);
-                    add_command.Parameters.AddWithValue("@enemyid", enemyid);
-                    add_command.Parameters.AddWithValue("@skill", skill);
-                    add_command.Parameters.AddWithValue("@subskill", subskill);
-                    add_command.Parameters.AddWithValue("@actionpackid", actionpackid);
-                    add_command.Parameters.AddWithValue("@combatactionid", combatactionid);
-                    add_command.Parameters.AddWithValue("@options", options);
-                    add_command.ExecuteNonQueryAsync();
+                    VALUES(@id, @dmg, @wound, @manadamage, @enemyid, @skill, @subskill, @actionpackid, @combatactionid, @options, datetime(), unixepoch())
+                ", connection, transaction))
+                        {
+                            // Create parameters once to save CPU cycles
+                            command.Parameters.Add("@id", SqliteType.Integer);
+                            command.Parameters.Add("@dmg", SqliteType.Real);
+                            command.Parameters.Add("@wound", SqliteType.Real);
+                            command.Parameters.Add("@manadamage", SqliteType.Integer);
+                            command.Parameters.Add("@enemyid", SqliteType.Integer);
+                            command.Parameters.Add("@skill", SqliteType.Integer);
+                            command.Parameters.Add("@subskill", SqliteType.Integer);
+                            command.Parameters.Add("@actionpackid", SqliteType.Integer);
+                            command.Parameters.Add("@combatactionid", SqliteType.Integer);
+                            command.Parameters.Add("@options", SqliteType.Integer);
+
+                            // Loop through the batch, updating parameter values and executing
+                            foreach (var hit in batch)
+                            {
+                                command.Parameters["@id"].Value = hit.PlayerId;
+                                command.Parameters["@dmg"].Value = hit.Damage;
+                                command.Parameters["@wound"].Value = hit.Wound;
+                                command.Parameters["@manadamage"].Value = hit.ManaDamage;
+                                command.Parameters["@enemyid"].Value = hit.EnemyId;
+                                command.Parameters["@skill"].Value = hit.Skill;
+                                command.Parameters["@subskill"].Value = hit.Subskill;
+                                command.Parameters["@actionpackid"].Value = hit.ActionpackId;
+                                command.Parameters["@combatactionid"].Value = hit.CombatActionId;
+                                command.Parameters["@options"].Value = hit.Options;
+
+                                command.ExecuteNonQuery();
+                            }
+                        }
+                        // Commit the entire batch to the hard drive at once
+                        transaction.Commit();
+                    }
                 }
+                Debug.WriteLine($"[DB] Flushed {batch.Count} damage records to disk.");
             }
-            catch 
+            catch (Exception ex)
             {
-                Debug.WriteLine("couldnt send sql command");
+                Debug.WriteLine($"[DB] Failed to flush batch: {ex.Message}");
+                // Optional: Re-queue the batch so data isn't lost on transient errors
+                foreach (var hit in batch)
+                {
+                    _damageQueue.Enqueue(hit);
+                }
             }
         }
 

--- a/Mabinogi_Damage_Tracker.client/Mabinogi_Damage_Tracker.client.esproj.user
+++ b/Mabinogi_Damage_Tracker.client/Mabinogi_Damage_Tracker.client.esproj.user
@@ -26,8 +26,8 @@
   "name": "localhost (Chrome)",
   "type": "chrome",
   "request": "launch",
-  "url": "https://localhost:5004",
-  "webRoot": "C:\\Checkout\\git\\Mabinogi_Damage_Tracker\\Mabinogi_Damage_Tracker.client"
+  "url": "https://localhost:3000",
+  "webRoot": "C:\\Checkout\\git\\Mabinogi-Damage-Tracker\\Mabinogi_Damage_Tracker.client"
 }</LaunchJsonTarget>
   </PropertyGroup>
 </Project>

--- a/Mabinogi_Damage_Tracker.client/src/components/SettingsMenu.jsx
+++ b/Mabinogi_Damage_Tracker.client/src/components/SettingsMenu.jsx
@@ -32,6 +32,9 @@ export default function SettingsMenu() {
     const [severity, setSeverity] = useState("success");
     const [AlertMessage, setAlertMessage] = useState("");
 
+    const [flushEnabled, setFlushEnabled] = useState(null);
+    const [flushMs, setFlushMs] = useState("");
+
     useEffect(() => {
         // Fetch adapter settings
         fetch(`http://${window.location.hostname}:5004/Home/GetCurrentAdapter`)
@@ -41,13 +44,23 @@ export default function SettingsMenu() {
             })
             .catch(error => console.error('Error:', error));
 
-
         fetch(`http://${window.location.hostname}:5004/Home/GetAllAdapters`)
             .then(response => response.json())
             .then(data => {
                 setAdapters(data);
             })
             .catch(error => console.error('Error:', error));
+
+        // Fetch Flush Settings
+        fetch(`http://${window.location.hostname}:5004/Home/GetFlushSettings`)
+            .then(response => response.json())
+            .then(data => {
+                if (data) {
+                    setFlushEnabled(data.enable !== 0);
+                    setFlushMs(data.ms);
+                }
+            })
+            .catch(error => console.error('Error fetching flush settings:', error));
     }, []);
 
     const handleThemeChange = (event) => {
@@ -60,7 +73,6 @@ export default function SettingsMenu() {
         const selectedLanguage = event.target.value;
         i18n.changeLanguage(selectedLanguage);
         localStorage.setItem('lang', selectedLanguage);
-        //console.log(i18n.language);
     };
 
     const handleAdapterChange = async (event) => {
@@ -78,11 +90,41 @@ export default function SettingsMenu() {
         }
     };
 
+    //flush settings
+    const handleFlushEnableChange = async (event) => {
+        const isEnabled = event.target.checked;
+        setFlushEnabled(isEnabled);
+        await saveFlushSettings(isEnabled, flushMs);
+    };
+
+    const handleFlushMsChange = async (value) => {
+        setFlushMs(value);
+        await saveFlushSettings(flushEnabled, value);
+    };
+
+    
+    const saveFlushSettings = async (enabled, ms) => {
+        const enableInt = enabled ? 1 : 0;
+        try {
+            const response = await fetch(`http://${window.location.hostname}:5004/Home/SaveFlushSettings?enable=${enableInt}&ms=${ms}`);
+            setOpen(true);
+            if (response.ok) {
+                setSeverity('success');
+                setAlertMessage("Database Flush Settings Saved.");
+            } else {
+                setSeverity('error');
+                setAlertMessage("Error Saving Flush Settings.");
+            }
+        } catch (error) {
+            console.error("Error saving flush settings", error);
+        }
+    };
+    // ------------------------------------
+
     const handleCloseSnackbar = (event, reason) => {
         if (reason === 'clickaway') {
             return;
         }
-
         setOpen(false);
     };
 
@@ -223,6 +265,44 @@ export default function SettingsMenu() {
                 </FormControl>
             </Box>
             <Divider />
+
+            {/*Database Que and Flush Settings Block*/}
+            {flushEnabled !== null && (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    <Box>
+                        <Typography sx={{ alignSelf: 'flex-start' }} variant='h4'> {t('settings.flushsettingstitle')}</Typography>
+                        <Typography sx={{ alignSelf: 'flex-start' }} variant='subtitle2' color="text.secondary">
+                            {t('settings.flushsettingsdescription', { returnObjects: true }).map((line, index, array) => (
+                                <React.Fragment key={index}>
+                                    {line}
+                                    {index < array.length - 1 && <br />}
+                                </React.Fragment>
+                            ))}
+                        </Typography>
+                    </Box>
+
+                    <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <Typography>{t('settings.flushsettingenable')}</Typography>
+                        <Switch checked={flushEnabled} onChange={handleFlushEnableChange} />
+                    </Box>
+
+                    <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <Typography>{t('settings.flushsettingtime')}</Typography>
+                        <NumberField
+                            label={t('common.delay')}
+                            min={100}
+                            max={60000}
+                            step={100}
+                            units="ms"
+                            value={flushMs}
+                            onValueChange={handleFlushMsChange}
+                        />
+                    </Box>
+                </Box>
+            )}
+            <Divider />
+            {/* ------------------------------------------------ */}
+
             <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
                 <Box>
                     <Typography sx={{ alignSelf: 'flex-start' }} variant='h4'>{t('settings.restartParse')}</Typography>
@@ -240,8 +320,8 @@ export default function SettingsMenu() {
                             setAlertMessage("Failed to restart adapter.");
                         }
                     }}
-                    >
-                {t('settings.restart')}</Button>
+                >
+                    {t('settings.restart')}</Button>
             </Box>
 
             {/* Feedback component */}

--- a/Mabinogi_Damage_Tracker.client/src/components/SettingsMenu.jsx
+++ b/Mabinogi_Damage_Tracker.client/src/components/SettingsMenu.jsx
@@ -231,7 +231,7 @@ export default function SettingsMenu() {
                     <Typography sx={{ alignSelf: 'flex-start' }} variant='h4'>{t('settings.pollingRate')}</Typography>
                     <Typography sx={{ alignSelf: 'flex-start' }} variant='subtitle'>{t('settings.pollingRateDescription')}</Typography>
                 </Box>
-                <NumberField label="Number Field" min={10} max={10000} units="ms"
+                <NumberField label="Number Field" min={10} max={10000} units="ms" step={100}
                     value={pollingRate}
                     onValueChange={(value) => {
 

--- a/Mabinogi_Damage_Tracker.client/src/localization/i18n/en.json
+++ b/Mabinogi_Damage_Tracker.client/src/localization/i18n/en.json
@@ -11,7 +11,8 @@
     "numberOfPlayers": "Number of Players",
     "damageOverTime": "Damage Over Time",
     "largestHit": "Largest Hit",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "delay":  "Delay"
   },
   "sideMenu": {
     "home": "Home",
@@ -45,7 +46,16 @@
     "topEnemyCount": "Top X target count",
     "topEnemyCountDescription": "Sets the default X used by the Analytics Top X Targets filter. Targets are ranked by total damage dealt within the selected time range.",
     "showBattleSummary": "Show Battle Summary",
-    "showBattleSummaryDescription": "Display a shareable battle summary panel on the Analytics screen"
+    "showBattleSummaryDescription": "Display a shareable battle summary panel on the Analytics screen",
+    "flushsettingstitle": "Database Que and Flush Settings",
+    "flushsettingsdescription": [
+      "Restart server after changing these settings. If running on slow drives like hard drives keep enabled.",
+      "The larger the number the less disk writes but your live page will update slower.",
+      "Also reduces wear on solid state drives by writing less over all data.",
+      "Can potentially change the accuracy of 'Burst damage' information but all other data is fully accurate."
+    ],
+    "flushsettingenable": "Enable DB Queuing",
+    "flushsettingtime": "Flush Time"
   },
   "live": {
     "title": "Live",


### PR DESCRIPTION
implemented DB queuing and flushing to reduce IO writes and memory wear. for long runs with lots of players it could reduce disk writes by 25x!
 No noticeable accuracy differences between enabling or disabling queuing. There does seem to be some differences in the burst section title card but it also is not very consistent when redoing an entire capture. It can vary by 10-15%. Most likely an issue in the bucketing section but not critical.

all other data is fully accurate regardless of queuing. only downside to large ques is once they come close to or surpass the polling rate you will get jagged rises in damage on the live view page. The analytics page looks normal.

also updated file debugging so files can be read at real time or with a playback speed